### PR TITLE
Remove future_parser setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,6 @@ Please see #future-parser-support for why this might be required.
 plugins::puppet::templates::url: https://github.com/nwops/retrospec-templates
 plugins::puppet::templates::ref: master
 plugins::puppet::enable_beaker_tests: true
-plugins::puppet::enable_future_parser: true
 plugins::puppet::template_dir: /Users/username/.retrospec/repos/retrospec-puppet-templates
 # used when creating new modules
 plugins::puppet::namespace: organization

--- a/lib/retrospec/plugins/v1/plugin/puppet.rb
+++ b/lib/retrospec/plugins/v1/plugin/puppet.rb
@@ -27,7 +27,6 @@ module Retrospec
         def initialize(supplied_module_path = nil, config = {})
           super
           @manifest_dir = File.join(supplied_module_path, 'manifests')
-          Utilities::PuppetModule.instance.future_parser = config_data[:enable_future_parser]
           # user supplied a template path or user wants to use local templates
           @template_dir = setup_user_template_dir(config_data[:template_dir], config_data[:scm_url], config_data[:ref])
         end
@@ -78,7 +77,6 @@ module Retrospec
           template_dir = ENV['RETROSPEC_TEMPLATES_DIR'] || plugin_config['plugins::puppet::template_dir'] || File.expand_path('~/.retrospec/repos/retrospec-puppet-templates')
           scm_url = ENV['RETROSPEC_PUPPET_SCM_URL'] || plugin_config['plugins::puppet::templates::url']
           scm_branch = ENV['RETROSPEC_PUPPET_SCM_BRANCH'] || plugin_config['plugins::puppet::templates::ref'] || 'master'
-          future_parser = plugin_config['plugins::puppet::enable_future_parser'] || false
           beaker_tests  = plugin_config['plugins::puppet::enable_beaker_tests'] || false
           # a list of subcommands for this plugin
           sub_commands  = %w(new_module new_fact new_type new_provider new_function new_report)
@@ -101,7 +99,6 @@ Generates puppet rspec test code based on the classes and defines inside the man
             opt :branch, 'Branch you want to use for the retrospec template repo', :type => :string, :required => false,
                 :default => scm_branch
             opt :enable_beaker_tests, 'Enable the creation of beaker tests', :require => false, :type => :boolean, :default => beaker_tests
-            opt :enable_future_parser, 'Enables the future parser only during validation', :default => future_parser, :require => false, :type => :boolean
             stop_on sub_commands
           end
           # the passed in options will always override the config file

--- a/lib/retrospec/plugins/v1/plugin/puppet_module.rb
+++ b/lib/retrospec/plugins/v1/plugin/puppet_module.rb
@@ -5,7 +5,6 @@ require_relative 'exceptions'
 module Utilities
   class PuppetModule
     attr_writer :module_path
-    attr_accessor :future_parser
 
     include Singleton
 
@@ -74,17 +73,12 @@ module Utilities
         # validate the manifest files, because if one files doesn't work it affects everything
         files.each do |file|
           begin
-            Puppet[:parser] = 'future' if future_parser
             Puppet::Face[:parser, :current].validate(file)
           rescue SystemExit => e
             puts "Manifest file: #{file} has parser errors, please fix and re-check using\n puppet parser validate #{file}".fatal
             raise Retrospec::Puppet::ParserError
           end
         end
-        # switch back to current parser, since we rely on the AST parser
-        # unless the user enabled the future parser.
-        # Note: some functionality does not currently work with future_parser
-        Puppet[:parser] = 'current' unless future_parser
       end
       dir
     end


### PR DESCRIPTION
Puppet 4 doesn't have a future parser. It IS the future!